### PR TITLE
Fix typo in padding spacing comment

### DIFF
--- a/src/data-extraction/extractors-as-text.ts
+++ b/src/data-extraction/extractors-as-text.ts
@@ -52,7 +52,7 @@ export function extractPubNwtstyReferenceAsText(
 	context.find('.sz').each((_, el) => {
 		const element = $(el);
 		const previousText = element.prev().text();
-		// Fix por padding spacing
+		// Fix for padding spacing
 		if (previousText && !/\s$/.test(previousText) && !/^\s/.test(element.text())) {
 			element.prepend(' ');
 		}


### PR DESCRIPTION
## Summary
- correct a typo in a comment of `extractors-as-text.ts`

## Testing
- `npm run build` *(fails: Cannot find module 'cheerio' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f3c44d864832ebc3a772a41c50913